### PR TITLE
Do not use "noarch_python"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
-  noarch_python: True
   entry_points:
     - cpuinfo = cpuinfo:main
 


### PR DESCRIPTION
We build the package on all architectures anyway, and there seems to be a problem with the upload script for noarch_python packages.